### PR TITLE
Make CCC work with Minecraft 1.16-rc1, fix #11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '0.2.6-SNAPSHOT'
+    id 'fabric-loom' version '0.2.7-SNAPSHOT'
     id 'maven-publish'
     id 'com.jfrog.artifactory' version '4.9.0'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 maven_group = io.github.cottonmc
-mod_version = 1.0.0
+mod_version = 1.0.1
 
-minecraft_version = 1.15.2
-yarn_mappings = 1.15.2+build.14
-loader_version = 0.7.8+build.189
+minecraft_version = 1.16-rc1
+yarn_mappings = 1.16-rc1+build.5
+loader_version = 0.8.8+build.202

--- a/src/main/java/io/github/cottonmc/clientcommands/mixin/ClientCommandSourceMixin.java
+++ b/src/main/java/io/github/cottonmc/clientcommands/mixin/ClientCommandSourceMixin.java
@@ -1,11 +1,11 @@
 package io.github.cottonmc.clientcommands.mixin;
 
 import io.github.cottonmc.clientcommands.CottonClientCommandSource;
-import net.minecraft.util.Formatting;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientCommandSource;
-import net.minecraft.text.Text;
 import net.minecraft.text.LiteralText;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -17,16 +17,16 @@ public abstract class ClientCommandSourceMixin implements CottonClientCommandSou
 
     @Override
     public void sendFeedback(Text message) {
-        client.player.addChatMessage(message, false);
+        client.player.sendMessage(message, false);
     }
 
     @Override
     public void sendFeedback(Text message, boolean actionBar) {
-        client.player.addChatMessage(message, actionBar);
+        client.player.sendMessage(message, actionBar);
     }
 
     @Override
     public void sendError(Text text) {
-        client.player.addChatMessage(new LiteralText("").append(text).formatted(Formatting.RED), false);
+        client.player.sendMessage(new LiteralText("").append(text).formatted(Formatting.RED), false);
     }
 }

--- a/src/main/java/io/github/cottonmc/clientcommands/mixin/PlayerMixin.java
+++ b/src/main/java/io/github/cottonmc/clientcommands/mixin/PlayerMixin.java
@@ -3,15 +3,15 @@ package io.github.cottonmc.clientcommands.mixin;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import io.github.cottonmc.clientcommands.CottonClientCommandSource;
 import io.github.cottonmc.clientcommands.impl.CommandCache;
-import net.minecraft.util.Formatting;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientCommandSource;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.command.CommandException;
-import net.minecraft.text.Text;
 import net.minecraft.text.LiteralText;
+import net.minecraft.text.Text;
 import net.minecraft.text.TranslatableText;
+import net.minecraft.util.Formatting;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -28,7 +28,7 @@ public abstract class PlayerMixin {
     public ClientPlayNetworkHandler networkHandler;
 
     @Shadow
-    public abstract void addChatMessage(Text text_1, boolean boolean_1);
+    public abstract void sendMessage(Text text_1, boolean boolean_1);
 
     @Inject(method = "sendChatMessage", at = @At("HEAD"), cancellable = true)
     private void onChatMessage(String msg, CallbackInfo info) {
@@ -44,13 +44,13 @@ public abstract class PlayerMixin {
                 // Prevent sending the message
                 cancel = true;
         } catch (CommandException e) {
-            addChatMessage(e.getTextMessage().formatted(Formatting.RED), false);
+            sendMessage(e.getTextMessage().copy().formatted(Formatting.RED), false);
             cancel = true;
         } catch (CommandSyntaxException e) {
-            addChatMessage(new LiteralText(e.getMessage()).formatted(Formatting.RED), false);
+            sendMessage(new LiteralText(e.getMessage()).formatted(Formatting.RED), false);
             cancel = true;
         } catch (Exception e) {
-            addChatMessage(new TranslatableText("command.failed").formatted(Formatting.RED), false);
+            sendMessage(new TranslatableText("command.failed").formatted(Formatting.RED), false);
             cancel = true;
         }
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -12,7 +12,7 @@
     "issues": "https://github.com/CottonMC/ClientCommands/issues"
   },
   "depends": {
-    "fabricloader": ">=0.4.0"
+    "fabricloader": ">=0.8.8"
   },
   "mixins": [
     "mixins.cotton-client-commands.json"


### PR DESCRIPTION
This fixes issue #11 I opened earlier, updates mappings, and makes CCC compile against the current version of Fabric and Minecraft (1.16-rc1)
